### PR TITLE
HCPCO-176: Harden hcp-scada-provider repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v3.2.1
       with:
         go-version: '1.18'
     - run: go test ./...


### PR DESCRIPTION
# Description

Before the hcp-scada-provider repository can be open sourced we need to ensure that they are properly configured in the following way:

- [ ] Enable GitHub Advanced Security (with secrets scanning)
- [x]  add the repository to security-scanning.
- [x] Enabled Dependabot, preferably with Dependabot security updates.
- [x] Pin and only use trusted actions from the TSCCR.
- [x] Only use GitHub teams for granting access, not individual users.
- [ ] Consider adding branch protection rule(s) for main.

# Acceptance Criteria

The hcp-scada-provider repository has been configured as described above