### PR TITLE
HCPCO-199: Replace the Resource struct with the Link struct

### DIFF
--- a/api/types/structs.go
+++ b/api/types/structs.go
@@ -1,4 +1,4 @@
-package scada
+package types
 
 import (
 	"time"
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 )
 
+// ConnectRequest holds parameters for the broker RPC Connect call to the provider.
 type ConnectRequest struct {
 	Capability string
 	Meta       map[string]string
@@ -14,19 +15,23 @@ type ConnectRequest struct {
 	Message  string
 }
 
+// ConnectResponse is the response to a Connect RPC call.
 type ConnectResponse struct {
 	Success bool
 }
 
+// DisconnectRequest holds parameters for the broker RPC Disconnect call to the provider.
 type DisconnectRequest struct {
 	NoRetry bool          // Should the client retry
 	Backoff time.Duration // Minimum backoff
 	Reason  string
 }
 
+// DisconnectResponse is the response to a Disconnect RPC call.
 type DisconnectResponse struct {
 }
 
+// HandshakeRequest holds parameters for the broker RPC Handshake call to the provider.
 type HandshakeRequest struct {
 	// Service is the name of a data-plane Service connecting to the broker as a provider. Examples include consul, vault, waypoint, etc.
 	Service string
@@ -55,6 +60,7 @@ type HandshakeRequest struct {
 	Meta map[string]string
 }
 
+// HandshakeResponse is the response to a Handshake RPC call.
 type HandshakeResponse struct {
 	Authenticated bool
 	SessionID     string

--- a/provider.go
+++ b/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 
+	"github.com/hashicorp/hcp-scada-provider/api/types"
 	"github.com/hashicorp/hcp-scada-provider/internal/client"
 	"github.com/hashicorp/hcp-scada-provider/internal/client/dialer/tcp"
 	"github.com/hashicorp/hcp-scada-provider/internal/listener"
@@ -424,7 +425,7 @@ func (p *Provider) clientSetup() (*client.Client, error) {
 }
 
 // handshake does the initial handshake.
-func (p *Provider) handshake(client *client.Client) (*HandshakeResponse, error) {
+func (p *Provider) handshake(client *client.Client) (*types.HandshakeResponse, error) {
 	// Build the set of capabilities based on the registered handlers.
 	p.handlersLock.RLock()
 	capabilities := make(map[string]int, len(p.handlers))
@@ -438,7 +439,7 @@ func (p *Provider) handshake(client *client.Client) (*HandshakeResponse, error) 
 		return nil, fmt.Errorf("failed to get access token: %w", err)
 	}
 
-	req := HandshakeRequest{
+	req := types.HandshakeRequest{
 		Service:  p.config.Service,
 		Resource: p.config.Resource,
 
@@ -450,7 +451,7 @@ func (p *Provider) handshake(client *client.Client) (*HandshakeResponse, error) 
 		Capabilities: capabilities,
 		Meta:         p.GetMeta(),
 	}
-	resp := new(HandshakeResponse)
+	resp := new(types.HandshakeResponse)
 	if err := client.RPC("Session.Handshake", &req, resp); err != nil {
 		return nil, err
 	}
@@ -482,7 +483,7 @@ func (pe *providerEndpoint) setHijack(cb hijackFunc) {
 }
 
 // Connect is invoked by the broker to connect to a capability.
-func (pe *providerEndpoint) Connect(args *ConnectRequest, resp *ConnectResponse) error {
+func (pe *providerEndpoint) Connect(args *types.ConnectRequest, resp *types.ConnectResponse) error {
 	pe.p.logger.Info("connect requested", "capability", args.Capability)
 
 	// Handle potential flash
@@ -519,7 +520,7 @@ func (pe *providerEndpoint) Connect(args *ConnectRequest, resp *ConnectResponse)
 }
 
 // Disconnect is invoked by the broker to ask us to backoff.
-func (pe *providerEndpoint) Disconnect(args *DisconnectRequest, resp *DisconnectResponse) error {
+func (pe *providerEndpoint) Disconnect(args *types.DisconnectRequest, resp *types.DisconnectResponse) error {
 	if args.Reason == "" {
 		args.Reason = "<no reason provided>"
 	}

--- a/provider_test.go
+++ b/provider_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/hcp-scada-provider/api/types"
 	"github.com/hashicorp/hcp-scada-provider/internal/client"
 	"github.com/hashicorp/hcp-scada-provider/internal/listener"
 	"github.com/hashicorp/hcp-scada-provider/internal/test"
@@ -200,17 +201,17 @@ func testListener(t *testing.T) (string, net.Listener) {
 
 type TestHandshake struct {
 	t      *testing.T
-	expect *HandshakeRequest
+	expect *types.HandshakeRequest
 }
 
-func (t *TestHandshake) Handshake(arg *HandshakeRequest, resp *HandshakeResponse) error {
+func (t *TestHandshake) Handshake(arg *types.HandshakeRequest, resp *types.HandshakeResponse) error {
 	require.EqualValues(t.t, t.expect, arg)
 	resp.Authenticated = true
 	resp.SessionID = "foobarbaz"
 	return nil
 }
 
-func testHandshake(t *testing.T, list net.Listener, expect *HandshakeRequest) {
+func testHandshake(t *testing.T, list net.Listener, expect *types.HandshakeRequest) {
 	require := require.New(t)
 	conn, err := list.Accept()
 	require.NoError(err)
@@ -256,7 +257,7 @@ func TestProvider_Setup(t *testing.T) {
 	_, err = p.Listen("foo")
 	require.NoError(err)
 
-	exp := &HandshakeRequest{
+	exp := &types.HandshakeRequest{
 		Service: "test",
 		Resource: cloud.HashicorpCloudLocationLink{
 			ID: resourceID,
@@ -342,13 +343,13 @@ func TestProvider_Connect(t *testing.T) {
 	cc := msgpackrpc.NewCodec(false, false, stream)
 
 	// Make the connect rpc
-	args := &ConnectRequest{
+	args := &types.ConnectRequest{
 		Capability: "foo",
 		Meta: map[string]string{
 			"zip": "zap",
 		},
 	}
-	resp := &ConnectResponse{}
+	resp := &types.ConnectResponse{}
 	err = msgpackrpc.CallWithCodec(cc, "Provider.Connect", args, resp)
 	require.NoError(err)
 
@@ -384,11 +385,11 @@ func TestProvider_Disconnect(t *testing.T) {
 	cc := msgpackrpc.NewCodec(false, false, stream)
 
 	// Make the connect rpc
-	args := &DisconnectRequest{
+	args := &types.DisconnectRequest{
 		NoRetry: true,
 		Backoff: 300 * time.Second,
 	}
-	resp := &DisconnectResponse{}
+	resp := &types.DisconnectResponse{}
 	err = msgpackrpc.CallWithCodec(cc, "Provider.Disconnect", args, resp)
 	require.NoError(err)
 


### PR DESCRIPTION
# Description

Use the [the public hcp-sdk openapi link](https://github.com/hashicorp/hcp-sdk-go/blob/a296e2fdc4aa6571147cbad213072ec50461921f/clients/cloud-shared/v1/models/hashicorp_cloud_location_link.go#L18) on the provider side. 

# Acceptance Criteria

* provider lib are using the Link struct
