### PR TITLE
Correct HandshakeRequst struct field

### DIFF
--- a/api/types/structs.go
+++ b/api/types/structs.go
@@ -50,7 +50,7 @@ type HandshakeRequest struct {
 
 	// Resource is HCP Resource that is registering as a provider. This is recommended over ServiceID. The Resource's
 	// internal ID will be used to map providers to consumers which will be looked up from Resource-manager.
-	Resource models.HashicorpCloudLocationLink
+	Resource *models.HashicorpCloudLocationLink
 
 	// Capabilities is the list of services that this provider can provide. This could e.g. be "gRPC" or "HTTP".
 	Capabilities map[string]int

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 	// Resource contains information about the Resource the provider will
 	// register as.
-	Resource cloud.HashicorpCloudLocationLink
+	Resource *cloud.HashicorpCloudLocationLink
 
 	// HCPConfig is the HCP specific configuration, it provides information
 	// necessary to talk to HCP APIs.
@@ -41,13 +41,18 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("missing Service")
 	}
 
+	if c.Resource == nil {
+		return fmt.Errorf("missing Resource")
+	}
 	err := resource.Validate(c.Resource)
 	if err != nil {
-		return fmt.Errorf("resource is invalid: %w", err)
+		return fmt.Errorf("invalid Resource: %w", err)
 	}
+
 	if c.HCPConfig == nil {
 		return fmt.Errorf("missing HCPConfig")
 	}
+
 	if c.Logger == nil {
 		return fmt.Errorf("missing Logger")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,7 @@ type stubHCPConfig struct {
 func validConfig() *Config {
 	return &Config{
 		Service: "my-service",
-		Resource: cloud.HashicorpCloudLocationLink{
+		Resource: &cloud.HashicorpCloudLocationLink{
 			ID:   "resource-id",
 			Type: "hashicorp.test.resource",
 			Location: &cloud.HashicorpCloudLocationLocation{
@@ -50,11 +50,18 @@ func TestConfig_Invalid(t *testing.T) {
 			expectedError: "missing Service",
 		},
 		{
+			name: "missing resource",
+			mutate: func(config *Config) {
+				config.Resource = nil
+			},
+			expectedError: "missing Resource",
+		},
+		{
 			name: "invalid resource",
 			mutate: func(config *Config) {
 				config.Resource.ID = ""
 			},
-			expectedError: "resource is invalid: missing resource ID",
+			expectedError: "invalid Resource: missing resource ID",
 		},
 		{
 			name: "missing HCP Config",
@@ -91,7 +98,7 @@ func testProviderConfig() *Config {
 			"127.0.0.1:65500", // Blackhole
 			false,
 		),
-		Resource: cloud.HashicorpCloudLocationLink{
+		Resource: &cloud.HashicorpCloudLocationLink{
 			ID:   resourceID,
 			Type: resourceType,
 			Location: &cloud.HashicorpCloudLocationLocation{

--- a/internal/resource/validation.go
+++ b/internal/resource/validation.go
@@ -6,7 +6,7 @@ import (
 	cloud "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 )
 
-func Validate(resource cloud.HashicorpCloudLocationLink) error {
+func Validate(resource *cloud.HashicorpCloudLocationLink) error {
 	if resource.Location == nil {
 		return fmt.Errorf("missing resource location")
 	}

--- a/provider_test.go
+++ b/provider_test.go
@@ -32,7 +32,7 @@ func TestSCADAProvider(t *testing.T) {
 			Service:   "test",
 			Logger:    nil,
 			HCPConfig: test.NewStaticHCPCloudDevConfig(),
-			Resource: cloud.HashicorpCloudLocationLink{
+			Resource: &cloud.HashicorpCloudLocationLink{
 				ID:       "ID",
 				Type:     "Type",
 				Location: &cloud.HashicorpCloudLocationLocation{},
@@ -48,7 +48,7 @@ func TestSCADAProvider(t *testing.T) {
 			Service:   "test",
 			Logger:    hclog.Default(),
 			HCPConfig: nil,
-			Resource: cloud.HashicorpCloudLocationLink{
+			Resource: &cloud.HashicorpCloudLocationLink{
 				ID:       "ID",
 				Type:     "Type",
 				Location: &cloud.HashicorpCloudLocationLocation{},
@@ -64,7 +64,7 @@ func TestSCADAProvider(t *testing.T) {
 			Service:   "test",
 			Logger:    hclog.Default(),
 			HCPConfig: test.NewStaticHCPCloudDevConfig(),
-			Resource: cloud.HashicorpCloudLocationLink{
+			Resource: &cloud.HashicorpCloudLocationLink{
 				ID:       "ID",
 				Type:     "",
 				Location: nil,
@@ -80,7 +80,7 @@ func TestSCADAProvider(t *testing.T) {
 			Service:   "test",
 			Logger:    hclog.Default(),
 			HCPConfig: test.NewStaticHCPCloudDevConfig(),
-			Resource: cloud.HashicorpCloudLocationLink{
+			Resource: &cloud.HashicorpCloudLocationLink{
 				ID:       "ID",
 				Type:     "",
 				Location: &cloud.HashicorpCloudLocationLocation{},
@@ -96,7 +96,7 @@ func TestSCADAProvider(t *testing.T) {
 			Service:   "test",
 			Logger:    hclog.Default(),
 			HCPConfig: test.NewStaticHCPCloudDevConfig(),
-			Resource: cloud.HashicorpCloudLocationLink{
+			Resource: &cloud.HashicorpCloudLocationLink{
 				ID:       "",
 				Type:     "Type",
 				Location: &cloud.HashicorpCloudLocationLocation{},
@@ -112,7 +112,7 @@ func TestSCADAProvider(t *testing.T) {
 			Service:   "test",
 			Logger:    hclog.Default(),
 			HCPConfig: test.NewStaticHCPCloudDevConfig(),
-			Resource: cloud.HashicorpCloudLocationLink{
+			Resource: &cloud.HashicorpCloudLocationLink{
 				ID:       "ID",
 				Type:     "Type",
 				Location: &cloud.HashicorpCloudLocationLocation{},
@@ -259,7 +259,7 @@ func TestProvider_Setup(t *testing.T) {
 
 	exp := &types.HandshakeRequest{
 		Service: "test",
-		Resource: cloud.HashicorpCloudLocationLink{
+		Resource: &cloud.HashicorpCloudLocationLink{
 			ID: resourceID,
 			Location: &cloud.HashicorpCloudLocationLocation{
 				ProjectID:      projectID,


### PR DESCRIPTION
`HandshakeRequest` should address of Link struct instead of a value. Fixed it to take address. To keep it consistent the `Config` also takes address of Link struct which resulted in test updates.