### PR TITLE
HCPCO-165: adding Refresh to HandshakeResponse/changing the data structures

### DIFF
--- a/types/structs.go
+++ b/types/structs.go
@@ -40,5 +40,7 @@ type HandshakeResponse struct {
 	Authenticated bool
 	SessionID     string
 	Reason        string
-	Refresh       time.Duration // the recommended refresh interval before the next re-handshake
+	// Expiry is the expiration time of the session. If the session is not re-handshaked
+	// before Expiry it will get disconnected.
+	Expiry time.Time
 }


### PR DESCRIPTION
# Description

This is client piece of work for HCPCO2-207 ticket. Specifically, the provider client should re-handshake just before the server/broker is about to disconnect the session to avoid re-connections.