### PR TITLE
Store address of resource Link in HandshakeRequest

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -535,7 +535,7 @@ func (p *Provider) handshake(ctx context.Context, client *client.Client) (*types
 
 	req := types.HandshakeRequest{
 		Service:  p.config.Service,
-		Resource: p.config.Resource,
+		Resource: &p.config.Resource,
 
 		AccessToken: oauthToken.AccessToken,
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -264,7 +264,7 @@ func TestProvider_Setup(t *testing.T) {
 
 	exp := &types.HandshakeRequest{
 		Service: "test",
-		Resource: cloud.HashicorpCloudLocationLink{
+		Resource: &cloud.HashicorpCloudLocationLink{
 			ID: resourceID,
 			Location: &cloud.HashicorpCloudLocationLocation{
 				ProjectID:      projectID,

--- a/types/structs.go
+++ b/types/structs.go
@@ -23,7 +23,7 @@ type HandshakeRequest struct {
 
 	// Resource is HCP Resource that is registering as a provider. This is recommended over ServiceID. The Resource's
 	// internal ID will be used to map providers to consumers which will be looked up from Resource-manager.
-	Resource models.HashicorpCloudLocationLink
+	Resource *models.HashicorpCloudLocationLink
 
 	// Capabilities is the list of services that this provider can provide. This could e.g. be "gRPC" or "HTTP".
 	Capabilities map[string]int


### PR DESCRIPTION
Since as of now this is optional, it makes sense to store it as address. It becomes easier to do validation in broker with this. In fact nothing needs to be changed. 

@dgregoire This brings back #12. I know we discussed and decided to leave it but now that I am working on using these structs in broker I feel this should be done because:
* broker validation does not need changing 
* Resource is optional until mTLS phases out