### PR TITLE
HCPCO2-165: fix a deadlock in the ticker triggered re-handshake

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -400,7 +400,11 @@ func (p *Provider) run() context.CancelFunc {
 				// it's time to refresh the session with the broker
 				// by issuing a re-handshake
 				go func() {
-					p.actions <- actionRehandshake
+					select {
+					case p.actions <- actionRehandshake:
+					case <-ctx.Done():
+					}
+
 				}()
 
 			case action := <-p.actions:

--- a/provider.go
+++ b/provider.go
@@ -400,11 +400,13 @@ func (p *Provider) run() context.CancelFunc {
 				// it's time to refresh the session with the broker
 				// by issuing a re-handshake
 				go func() {
+					// `case SessionStatusDisconnected` might happen while we're waiting to
+					// write to p.actions. Unblock on ctx being canceled to handle that eventuality.
+					// it might be better here to call handshake directly.
 					select {
 					case p.actions <- actionRehandshake:
 					case <-ctx.Done():
 					}
-
 				}()
 
 			case action := <-p.actions:


### PR DESCRIPTION
# Description

In this code:

```
case <-ticker.C:
	go func() {
		p.actions <- actionRehandshake
	}()
```

If this is waiting to write to `p.actions` while the main loop is processing `case SessionStatusDisconnected:`, that go routine will block forever.