### PR TITLE
Prepare before making a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+This file will contain all notable changes to this repository. Any new releases with changes will be documented here.
+
+## 0.0.1 (September 9 2022)
+First version of the library containing capability to connect to SCADA broker as SCADA provider using HCP identity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 This file will contain all notable changes to this repository. Any new releases with changes will be documented here.
 
-## 0.0.1 (September 9 2022)
+## 0.1.0 (September 9 2022)
 First version of the library containing capability to connect to SCADA broker as SCADA provider using HCP identity.

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current version of the library
-var Version = "0.0.1"
+var Version = "0.1.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the current version of the library
+var Version = "0.0.1"


### PR DESCRIPTION
Setup a changelog file and version package containing current version of the library. I am basing this based on `hcp-sdk-go` and other repos in hashicorp.