### PR TITLE
HCPCO2-165: Inform why SCADA connection failed

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -60,7 +60,7 @@ func (te *timeError) Error() string {
 //
 // We encode the type that is meant to be returned in the error string as the first value, followed with a ":'.
 //
-//  return fmt.Errorf("%s: some problem happened with a function: %v", provider.ErrorPrefixes[ErrPermissionDenied], errors.New("some IO problem"))
+//  return fmt.Errorf("%s: a problem happened with a function: %v", provider.ErrorPrefixes[ErrPermissionDenied], errors.New("a IO problem"))
 func NewTimeError(err error) timeError {
 	var extract = func(err error) error { // split err along ":"
 		split := strings.Split(err.Error(), ":")
@@ -68,7 +68,7 @@ func NewTimeError(err error) timeError {
 			return err
 		}
 
-		// if split[0] is a known error in reverseProviderErrors,
+		// if split[0] is a known error in reverseErrorPrefixes,
 		// extract it and otherwise do nothing.
 		if err, found := reverseErrorPrefixes[split[0]]; found {
 			return err

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,10 @@
 package provider
 
-import "errors"
+import (
+	"errors"
+	"strings"
+	"time"
+)
 
 var (
 	// these are provider side errors
@@ -28,5 +32,57 @@ func init() {
 	//
 	for k, v := range ErrorPrefixes {
 		reverseErrorPrefixes[v] = k
+	}
+}
+
+// timeError is a container for an error
+// and a timestamp of when that error occured.
+type timeError struct {
+	time.Time
+	error
+}
+
+// Error implements the error interface on timeError.
+func (te *timeError) Error() string {
+	if te.error != nil {
+		return te.error.Error()
+	} else {
+		return ""
+	}
+}
+
+// NewTimeError tries to map err to one of the known error values in ErrorPrefixes and
+// it returns a timeError value set to either the error it found in ErrorPrefixes,
+// or set to the caller's err. Time is always set to Now().
+//
+// Its used to return error codes over RPC connections because RPC calls
+// provide only the type returned by errors.New().
+//
+// We encode the type that is meant to be returned in the error string as the first value, followed with a ":'.
+//
+//  return fmt.Errorf("%s: some problem happened with a function: %v", provider.ErrorPrefixes[ErrPermissionDenied], errors.New("some IO problem"))
+func NewTimeError(err error) timeError {
+	var extract = func(err error) error { // split err along ":"
+		split := strings.Split(err.Error(), ":")
+		if len(split) < 2 {
+			return err
+		}
+
+		// if split[0] is a known error in reverseProviderErrors,
+		// extract it and otherwise do nothing.
+		if err, found := reverseErrorPrefixes[split[0]]; found {
+			return err
+		}
+
+		return err
+	}
+	//
+	if err != nil {
+		err = extract(err)
+	}
+	//
+	return timeError{
+		Time:  time.Now(),
+		error: err,
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,32 @@
+package provider
+
+import "errors"
+
+var (
+	// these are provider side errors
+	ErrProviderNotStarted = errors.New("the provider is not started")                            // the provider is not started
+	ErrInvalidCredentials = errors.New("could not obtain a token with the supplied credentials") // could not obtain a token with the configured credentials
+	// this is a broker side error
+	ErrPermissionDenied = errors.New("principal does not have the permision to register as a provider") // the principal behind the creds does not have permission to register as provider.
+)
+
+// ErrorPrefixes maintains a mapping between error types and their variable names.
+// The broker is using those to return error codes over RPC connections. RPC calls
+// provide only the type returned by errors.New().
+var ErrorPrefixes = map[error]string{
+	ErrProviderNotStarted: "ErrProviderNotStarted",
+	ErrInvalidCredentials: "ErrInvalidCredentials",
+	ErrPermissionDenied:   "ErrPermissionDenied",
+}
+
+// reverseErrorPrefixes keeps a reverse mapping of ProviderErrors.
+// It's automatically created at start by init().
+var reverseErrorPrefixes map[string]error
+
+func init() {
+	reverseErrorPrefixes = make(map[string]error, len(ErrorPrefixes))
+	//
+	for k, v := range ErrorPrefixes {
+		reverseErrorPrefixes[v] = k
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,14 +1,21 @@
 package provider
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestReverseProviderErrors verifies that init correctly
-// sets up reverseProviderErrors.
-func TestReverseProviderErrors(t *testing.T) {
+var (
+	errTimeErrorUnknown = errors.New("testing error")
+	errTimeErrorKnown   = errors.New("ErrProviderNotStarted: testing error")
+)
+
+// TestReverseErrorPrefixes verifies that init correctly
+// sets up reverseErrorPrefixes.
+func TestReverseErrorPrefixes(t *testing.T) {
 	var r = require.New(t)
 
 	for k, v := range ErrorPrefixes {
@@ -16,4 +23,52 @@ func TestReverseProviderErrors(t *testing.T) {
 		r.True(found, "error %s not found in reverseProviderErrors", v)
 		r.Equal(err, k, "expected error %s", v)
 	}
+}
+
+func TestNewTimeErrorUnknown(t *testing.T) {
+	var r = require.New(t)
+
+	te := NewTimeError(errTimeErrorUnknown)
+	r.NotEmpty(te.Time)
+	r.True(te.Time.Before(time.Now()))
+	r.Equal(errTimeErrorUnknown, te.error)
+}
+
+// TestNewTimeErrorBase checks the standard behavior of timeError.
+// creating a new timeError with an unknown value and checking it's value.
+func TestNewTimeErrorKnown(t *testing.T) {
+	var r = require.New(t)
+
+	te := NewTimeError(errTimeErrorKnown)
+	r.NotEmpty(te.Time)
+	r.True(te.Time.Before(time.Now()))
+	r.Equal(ErrProviderNotStarted, te.error)
+}
+
+// TestNewTimeErrorError confirms that timeError.Error() functions correctly.
+func TestNewTimeErrorError(t *testing.T) {
+	var r = require.New(t)
+
+	te := NewTimeError(errTimeErrorUnknown)
+	r.Equal(errTimeErrorUnknown.Error(), te.Error())
+
+}
+
+// TestNewTimeErrorNil assuages that NewTimeError functions correctly when created with a nil value.
+func TestNewTimeErrorNil(t *testing.T) {
+	var r = require.New(t)
+
+	te := NewTimeError(nil)
+	r.NotEmpty(te.Time)
+	r.True(te.Time.Before(time.Now()))
+	r.Nil(te.error)
+}
+
+// TestNewTimeErrorErrorNil is a check on the behavior of timeError.Error()
+// when timeError.error is nil.
+func TestNewTimeErrorErrorNil(t *testing.T) {
+	var r = require.New(t)
+
+	te := NewTimeError(nil)
+	r.Equal("", te.Error())
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReverseProviderErrors verifies that init correctly
+// sets up reverseProviderErrors.
+func TestReverseProviderErrors(t *testing.T) {
+	var r = require.New(t)
+
+	for k, v := range ErrorPrefixes {
+		err, found := reverseErrorPrefixes[v]
+		r.True(found, "error %s not found in reverseProviderErrors", v)
+		r.Equal(err, k, "expected error %s", v)
+	}
+}

--- a/interface.go
+++ b/interface.go
@@ -41,6 +41,13 @@ type SCADAProvider interface {
 	// LastError returns the last error recorded in the provider
 	// connection state engine as well as the time at which the error occured.
 	// That record is erased at each occasion when the provider achieves a new connection.
+	//
+	// A few common internal error will return a known type:
+	// * ErrProviderNotStarted: the provider is not started
+	// * ErrPermissionDenied: could not obtain a token with the supplied credentials (not supported yet)
+	// * ErrInvalidCredentials: principal does not have the permision to register as a provider (not supported yet)
+	//
+	// Any other internal error will be returned directly and unchanged.
 	LastError() (time.Time, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"net"
+	"time"
 )
 
 // SCADAProvider allows to expose services via SCADA capabilities.
@@ -36,6 +37,11 @@ type SCADAProvider interface {
 
 	// SessionStatus will return the status of the SCADA connection.
 	SessionStatus() SessionStatus
+
+	// LastError returns the last error recorded in the provider
+	// connection state engine as well as the time at which the error occured.
+	// That record is erased at each occasion when the provider achieves a new connection.
+	LastError() (time.Time, error)
 }
 
 // SessionStatus is used to express the current status of the SCADA session.

--- a/interface.go
+++ b/interface.go
@@ -44,10 +44,8 @@ type SCADAProvider interface {
 	//
 	// A few common internal error will return a known type:
 	// * ErrProviderNotStarted: the provider is not started
-	// * ErrPermissionDenied: could not obtain a token with the supplied credentials (not supported yet)
-	// * ErrInvalidCredentials: principal does not have the permision to register as a provider (not supported yet)
-	//
-	// Any other internal error will be returned directly and unchanged.
+	// * ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+	// * ErrPermissionDenied: principal does not have the permision to register as a provider (not supported yet)
 	LastError() (time.Time, error)
 }
 

--- a/provider.go
+++ b/provider.go
@@ -258,6 +258,13 @@ func (p *Provider) SessionStatus() SessionStatus {
 	return p.sessionStatus
 }
 
+// LastError returns the last error recorded in the provider
+// connection state engine as well as the time at which the error occured.
+// That record is erased at each occasion when the provider achieves a new connection.
+func (p *Provider) LastError() (time.Time, error) {
+	return time.Now(), nil
+}
+
 func (p *Provider) backoffReset() {
 	// Reset the previous backoff
 	p.backoffLock.Lock()

--- a/provider.go
+++ b/provider.go
@@ -267,8 +267,8 @@ func (p *Provider) SessionStatus() SessionStatus {
 //
 // A few common internal error will return a known type:
 // * ErrProviderNotStarted: the provider is not started
-// * ErrPermissionDenied: could not obtain a token with the supplied credentials (not supported yet)
-// * ErrInvalidCredentials: principal does not have the permision to register as a provider (not supported yet)
+// * ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+// * ErrPermissionDenied: principal does not have the permision to register as a provider (not supported yet)
 //
 // Any other internal error will be returned directly and unchanged.
 func (p *Provider) LastError() (time.Time, error) {

--- a/provider.go
+++ b/provider.go
@@ -400,7 +400,11 @@ func (p *Provider) run() context.CancelFunc {
 				// it's time to refresh the session with the broker
 				// by issuing a re-handshake
 				go func() {
-					p.actions <- actionRehandshake
+					select {
+					case p.actions <- actionRehandshake:
+					case <-ctx.Done():
+					}
+
 				}()
 
 			case action := <-p.actions:

--- a/provider.go
+++ b/provider.go
@@ -96,7 +96,7 @@ type Provider struct {
 
 	cancel context.CancelFunc
 
-	timeError timeError
+	lastError timeError
 }
 
 // construct is used to create a new provider.
@@ -112,7 +112,7 @@ func construct(config *Config) (*Provider, error) {
 		handlers:      map[string]handler{},
 		sessionStatus: SessionStatusDisconnected,
 		actions:       make(chan action),
-		timeError:     NewTimeError(ErrProviderNotStarted),
+		lastError:     NewTimeError(ErrProviderNotStarted),
 	}
 
 	return p, nil
@@ -264,8 +264,15 @@ func (p *Provider) SessionStatus() SessionStatus {
 // LastError returns the last error recorded in the provider
 // connection state engine as well as the time at which the error occured.
 // That record is erased at each occasion when the provider achieves a new connection.
+//
+// A few common internal error will return a known type:
+// * ErrProviderNotStarted: the provider is not started
+// * ErrPermissionDenied: could not obtain a token with the supplied credentials (not supported yet)
+// * ErrInvalidCredentials: principal does not have the permision to register as a provider (not supported yet)
+//
+// Any other internal error will be returned directly and unchanged.
 func (p *Provider) LastError() (time.Time, error) {
-	return p.timeError.Time, p.timeError.error
+	return p.lastError.Time, p.lastError.error
 }
 
 func (p *Provider) backoffReset() {
@@ -347,6 +354,8 @@ func (p *Provider) run() context.CancelFunc {
 	go func() {
 		defer cancel()
 		var cl *client.Client
+		// clear the lastError
+		p.lastError = NewTimeError(nil)
 		// engage in running the provider
 		for {
 			select {
@@ -373,12 +382,12 @@ func (p *Provider) run() context.CancelFunc {
 						// connect will error out and we go to SessionStatusWaiting
 						if client, err := p.connect(ctx); err != nil {
 							// make a note of the error
-							p.timeError = NewTimeError(err)
+							p.lastError = NewTimeError(err)
 							// not connected
 							statuses <- SessionStatusWaiting
 						} else if response, err := p.handshake(ctx, client); err != nil {
 							// make a note of the error
-							p.timeError = NewTimeError(err)
+							p.lastError = NewTimeError(err)
 							// connect closes client if any error
 							// occured at handshake() except for resp.Authenticated == false
 							statuses <- SessionStatusWaiting
@@ -394,14 +403,14 @@ func (p *Provider) run() context.CancelFunc {
 				case SessionStatusConnected:
 					p.sessionStatus = SessionStatusConnected
 					// reset the error
-					p.timeError = NewTimeError(nil)
+					p.lastError = NewTimeError(nil)
 					// reset any longer backoff period set by the Disconnect RPC call
 					p.backoffReset()
 					go func(client *client.Client) {
 						// Handle the session
 						if err := p.handleSession(ctx, client); err != nil {
 							// make a note of the error
-							p.timeError = NewTimeError(err)
+							p.lastError = NewTimeError(err)
 							// handleSession will always close client
 							// on errors or if the ctx is canceled().
 							// go to the waiting state
@@ -444,7 +453,7 @@ func (p *Provider) run() context.CancelFunc {
 						tickerReset(time.Now(), response.Expiry, ticker)
 					} else {
 						// make a note of the error
-						p.timeError = NewTimeError(err)
+						p.lastError = NewTimeError(err)
 					}
 				}
 
@@ -465,6 +474,7 @@ func (p *Provider) run() context.CancelFunc {
 				}()
 
 			case <-ret:
+				p.lastError = NewTimeError(ErrProviderNotStarted)
 				return
 				// ¯\_(ツ)_/¯
 			}

--- a/provider.go
+++ b/provider.go
@@ -400,11 +400,13 @@ func (p *Provider) run() context.CancelFunc {
 				// it's time to refresh the session with the broker
 				// by issuing a re-handshake
 				go func() {
+					// `case SessionStatusDisconnected` might happen while we're waiting to
+					// write to p.actions. Unblock on ctx being canceled to handle that eventuality.
+					// it might be better here to call handshake directly.
 					select {
 					case p.actions <- actionRehandshake:
 					case <-ctx.Done():
 					}
-
 				}()
 
 			case action := <-p.actions:


### PR DESCRIPTION
# Description

Currently, SCADA provider library has a status field that informs whether it is connected or disconnected. When it is disconnected, the consumer of the library does not know why it got disconnected. There should be method like GetDisconnectedReason for example that returns why the provider is disconnected. As of now the reasons are:

* provider not started
* client credentials are invalid
* principal identified by client credentials do not have permission to register as provider

# Notes

The goals are:
1. ability to return a provider error or error code from the broker over a RPC call
2. ~~not exposing extra fine grain error text to users of the provider lib~~
3. give the ability to the users of the provider lib to compare the return of LastError() with known types

* only `ErrProviderNotStarted` is supported for now
* `ErrPermissionDenied` will be supported after a change in the broker
* `ErrInvalidCredentials` needs more engineering around `config.HCPConfig.Token()`
* the `wait` state does not overwrite errors because `wait` only knows about `NoRetry` and `ctx.Cancel()`
