### PR TITLE
Review states in the provider lib

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -54,6 +54,8 @@ type SCADAProvider interface {
 	//   - ErrProviderNotStarted: the provider is not started
 	//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
 	//   - ErrPermissionDenied:   principal does not have the permision to register as a provider (not supported yet)
+	//
+	// Any other internal error will be returned directly and unchanged.
 	LastError() (time.Time, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -43,9 +43,9 @@ type SCADAProvider interface {
 	// That record is erased at each occasion when the provider achieves a new connection.
 	//
 	// A few common internal error will return a known type:
-	// * ErrProviderNotStarted: the provider is not started
-	// * ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
-	// * ErrPermissionDenied: principal does not have the permision to register as a provider (not supported yet)
+	//   - ErrProviderNotStarted: the provider is not started
+	//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+	//   - ErrPermissionDenied:   principal does not have the permision to register as a provider (not supported yet)
 	LastError() (time.Time, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -35,7 +35,15 @@ type SCADAProvider interface {
 	// not close the capability listeners.
 	Stop() error
 
-	// SessionStatus will return the status of the SCADA connection.
+	// SessionStatus returns the status of the SCADA connection.
+	//
+	// The possibles statuses are:
+	//   - SessionStatusDisconnected: the provider is stopped
+	//   - SessionStatusConnecting:   in the connect/handshake cycle
+	//   - SessionStatusConnected:    connected and serving scada consumers
+	//   - SessionStatusWaiting:      disconnected and waiting to retry a connection to the broker
+	//
+	// The full lifecycle is: connecting -> connected -> waiting -> connecting -> ... -> disconnected.
 	SessionStatus() SessionStatus
 
 	// LastError returns the last error recorded in the provider

--- a/provider.go
+++ b/provider.go
@@ -246,6 +246,14 @@ func (p *Provider) Stop() error {
 }
 
 // SessionStatus returns the status of the SCADA connection.
+//
+// The possibles statuses are:
+//   - SessionStatusDisconnected: the provider is stopped
+//   - SessionStatusConnecting:   in the connect/handshake cycle
+//   - SessionStatusConnected:    connected and serving scada consumers
+//   - SessionStatusWaiting:      disconnected and waiting to retry a connection to the broker
+//
+// The full lifecycle is: connecting -> connected -> waiting -> connecting -> ... -> disconnected.
 func (p *Provider) SessionStatus() SessionStatus {
 	return p.sessionStatus
 }

--- a/provider.go
+++ b/provider.go
@@ -255,9 +255,9 @@ func (p *Provider) SessionStatus() SessionStatus {
 // That record is erased at each occasion when the provider achieves a new connection.
 //
 // A few common internal error will return a known type:
-// * ErrProviderNotStarted: the provider is not started
-// * ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
-// * ErrPermissionDenied: principal does not have the permision to register as a provider (not supported yet)
+//   - ErrProviderNotStarted: the provider is not started
+//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+//   - ErrPermissionDenied:   principal does not have the permision to register as a provider (not supported yet)
 //
 // Any other internal error will be returned directly and unchanged.
 func (p *Provider) LastError() (time.Time, error) {


### PR DESCRIPTION
# Description

There’s been a report of minor confusion with the states in the provider lib, due to a change in messages between the PoC and the first open source [version](https://github.com/hashicorp/hcp-scada-provider).

I’m not totally sure that this is a problem, the team that reported this (Vault) already adapted by masking the waiting state into connecting. We could simply document the SessionStatusfunction better in the interface and give a better description of the states. 

When the library reports waiting it’s because it’s actually waiting, and it's not trying to connect. The confusion arose from the difference between connecting (during a call to connect) and waiting (waiting to reconnect if we disconnected).
If anything is mislabeled, it’s more disconnected because what is really means is that the provider is stopped and will not try to reconnect.

The full cycle is : connecting → connected → waiting→ connecting → … → disconnected