### PR TITLE
Add ErrInvalidCredentials to LastError

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -71,4 +72,37 @@ func TestNewTimeErrorErrorNil(t *testing.T) {
 
 	te := NewTimeError(nil)
 	r.Equal("", te.Error())
+}
+
+func TestPrefixErrorRetrieveError(t *testing.T) {
+	var r = require.New(t)
+
+	var err *oauth2.RetrieveError
+	if err := PrefixError("failed to get access token", err); err != nil {
+		r.Equal("ErrInvalidCredentials: failed to get access token: <nil>", err.Error())
+	} else {
+		t.Error("expected a prefixed error")
+	}
+}
+
+func TestPrefixErrorNil(t *testing.T) {
+	var r = require.New(t)
+
+	var err error
+	if err := PrefixError("failed to get access token", err); err != nil {
+		r.Equal("failed to get access token", err.Error())
+	} else {
+		t.Error("expected a prefixed error")
+	}
+}
+
+func TestPrefixErrorOther(t *testing.T) {
+	var r = require.New(t)
+
+	var err = errTimeErrorUnknown
+	if err := PrefixError("failed to get access token", err); err != nil {
+		r.Equal("failed to get access token: testing error", err.Error())
+	} else {
+		t.Error("expected a prefixed error")
+	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -77,9 +78,13 @@ func TestNewTimeErrorErrorNil(t *testing.T) {
 func TestPrefixErrorRetrieveError(t *testing.T) {
 	var r = require.New(t)
 
-	var err *oauth2.RetrieveError
+	var err *oauth2.RetrieveError = &oauth2.RetrieveError{
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+		},
+	}
 	if err := PrefixError("failed to get access token", err); err != nil {
-		r.Equal("ErrInvalidCredentials: failed to get access token: <nil>", err.Error())
+		r.Equal("ErrInvalidCredentials: failed to get access token: oauth2: cannot fetch token: \nResponse: ", err.Error())
 	} else {
 		t.Error("expected a prefixed error")
 	}

--- a/interface.go
+++ b/interface.go
@@ -52,7 +52,7 @@ type SCADAProvider interface {
 	//
 	// A few common internal error will return a known type:
 	//   - ErrProviderNotStarted: the provider is not started
-	//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+	//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials
 	//   - ErrPermissionDenied:   principal does not have the permision to register as a provider (not supported yet)
 	//
 	// Any other internal error will be returned directly and unchanged.

--- a/interface.go
+++ b/interface.go
@@ -44,7 +44,7 @@ type SCADAProvider interface {
 	//
 	// A few common internal error will return a known type:
 	// * ErrProviderNotStarted: the provider is not started
-	// * ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+	// * ErrInvalidCredentials: could not obtain a token with the supplied credentials
 	// * ErrPermissionDenied: principal does not have the permision to register as a provider (not supported yet)
 	LastError() (time.Time, error)
 }

--- a/provider.go
+++ b/provider.go
@@ -466,7 +466,7 @@ func (p *Provider) handshake(ctx context.Context, client *client.Client) (resp *
 	oauthToken, err = p.config.HCPConfig.Token()
 	if err != nil {
 		client.Close()
-		err = prefixTokenError("failed to get access token", err)
+		err = PrefixError("failed to get access token", err)
 		return nil, err
 	}
 
@@ -681,42 +681,6 @@ func calculateExpiryFactor(d time.Duration) time.Duration {
 	var factored = seconds * expiryFactor
 	d = time.Duration(factored) * time.Second
 	return d
-}
-
-// prefixTokenError prefixes err with prefixes from ErrorPrefixes depending on the type of err, and then adds text.
-//
-// the classic example is:
-//   err = prefixHandshake("failed to get access token", err)
-//
-// if err is type *oauth2.RetrieveError, prefixHandshakeError would return:
-//   fmt.Errorf("ErrInvalidCredentials: failed to get access token: %w", err)
-func prefixTokenError(text string, err error) error {
-	var prefix string
-	var e error
-
-	switch err.(type) {
-	case *oauth2.RetrieveError:
-		prefix = ErrorPrefixes[ErrInvalidCredentials]
-	}
-	if prefix != "" {
-		e = fmt.Errorf("%s", prefix)
-	}
-	if text != "" {
-		if e != nil {
-			e = fmt.Errorf("%v: %s", e, text)
-		} else {
-			e = fmt.Errorf("%s", text)
-		}
-	}
-	if err != nil {
-		if e != nil {
-			e = fmt.Errorf("%v: %w", e, err)
-		} else {
-			e = err
-		}
-	}
-
-	return e
 }
 
 var _ SCADAProvider = &Provider{}

--- a/provider.go
+++ b/provider.go
@@ -256,7 +256,7 @@ func (p *Provider) SessionStatus() SessionStatus {
 //
 // A few common internal error will return a known type:
 // * ErrProviderNotStarted: the provider is not started
-// * ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+// * ErrInvalidCredentials: could not obtain a token with the supplied credentials
 // * ErrPermissionDenied: principal does not have the permision to register as a provider (not supported yet)
 //
 // Any other internal error will be returned directly and unchanged.
@@ -681,7 +681,7 @@ func calculateExpiryFactor(d time.Duration) time.Duration {
 //   err = prefixHandshake("failed to get access token", err)
 //
 // if err is type *oauth2.RetrieveError, prefixHandshakeError would return:
-//   "ErrInvalidCredentials: failed to get access token: %w", err
+//   fmt.Errorf("ErrInvalidCredentials: failed to get access token: %w", err)
 func prefixTokenError(text string, err error) error {
 	var prefix string
 	var e error

--- a/provider.go
+++ b/provider.go
@@ -434,7 +434,11 @@ func (p *Provider) connect(ctx context.Context) (*client.Client, error) {
 	return client, nil
 }
 
-// handshake does the initial handshake.
+// handshake does the initial handshake. Handshake will return prefixed errors in certain scenarios:
+//   - if HCPConfig.Token() returns *oauth2.RetrieveError, it will prefix the error with ErrInvalidCredentials
+//   - client.RPC("Session.Handshake") might prefix the error with ErrPermissionDenied
+//
+// The prefixes are processed in NewTimeError called from the run() loop.
 func (p *Provider) handshake(ctx context.Context, client *client.Client) (resp *types.HandshakeResponse, err error) {
 	defer func() {
 		if err != nil {
@@ -454,7 +458,7 @@ func (p *Provider) handshake(ctx context.Context, client *client.Client) (resp *
 	oauthToken, err = p.config.HCPConfig.Token()
 	if err != nil {
 		client.Close()
-		err = fmt.Errorf("failed to get access token: %w", err)
+		err = prefixTokenError("failed to get access token", err)
 		return nil, err
 	}
 
@@ -669,6 +673,42 @@ func calculateExpiryFactor(d time.Duration) time.Duration {
 	var factored = seconds * expiryFactor
 	d = time.Duration(factored) * time.Second
 	return d
+}
+
+// prefixTokenError prefixes err with prefixes from ErrorPrefixes depending on the type of err, and then adds text.
+//
+// the classic example is:
+//   err = prefixHandshake("failed to get access token", err)
+//
+// if err is type *oauth2.RetrieveError, prefixHandshakeError would return:
+//   "ErrInvalidCredentials: failed to get access token: %w", err
+func prefixTokenError(text string, err error) error {
+	var prefix string
+	var e error
+
+	switch err.(type) {
+	case *oauth2.RetrieveError:
+		prefix = ErrorPrefixes[ErrInvalidCredentials]
+	}
+	if prefix != "" {
+		e = fmt.Errorf("%s", prefix)
+	}
+	if text != "" {
+		if e != nil {
+			e = fmt.Errorf("%v: %s", e, text)
+		} else {
+			e = fmt.Errorf("%s", text)
+		}
+	}
+	if err != nil {
+		if e != nil {
+			e = fmt.Errorf("%v: %w", e, err)
+		} else {
+			e = err
+		}
+	}
+
+	return e
 }
 
 var _ SCADAProvider = &Provider{}

--- a/provider.go
+++ b/provider.go
@@ -264,7 +264,7 @@ func (p *Provider) SessionStatus() SessionStatus {
 //
 // A few common internal error will return a known type:
 //   - ErrProviderNotStarted: the provider is not started
-//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials (not supported yet)
+//   - ErrInvalidCredentials: could not obtain a token with the supplied credentials
 //   - ErrPermissionDenied:   principal does not have the permision to register as a provider (not supported yet)
 //
 // Any other internal error will be returned directly and unchanged.

--- a/provider_test.go
+++ b/provider_test.go
@@ -488,7 +488,7 @@ func TestPrefixTokenErrorRetrieveError(t *testing.T) {
 	if err := prefixTokenError("failed to get access token", err); err != nil {
 		r.Equal("ErrInvalidCredentials: failed to get access token: <nil>", err.Error())
 	} else {
-		t.Error("prefixHandshakeError did not return any prefixes error")
+		t.Error("expected a prefixed error")
 	}
 }
 
@@ -499,7 +499,7 @@ func TestPrefixTokenErrorNil(t *testing.T) {
 	if err := prefixTokenError("failed to get access token", err); err != nil {
 		r.Equal("failed to get access token", err.Error())
 	} else {
-		t.Error("prefixHandshakeError did not return any prefixes error")
+		t.Error("expected a prefixed error")
 	}
 }
 
@@ -510,6 +510,6 @@ func TestPrefixTokenErrorOther(t *testing.T) {
 	if err := prefixTokenError("failed to get access token", err); err != nil {
 		r.Equal("failed to get access token: testing error", err.Error())
 	} else {
-		t.Error("prefixHandshakeError did not return any prefixes error")
+		t.Error("expected a prefixed error")
 	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -13,6 +13,7 @@ import (
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	"github.com/hashicorp/hcp-scada-provider/internal/client"
 	"github.com/hashicorp/hcp-scada-provider/internal/listener"
@@ -478,4 +479,37 @@ func testConn(t *testing.T) (net.Conn, net.Conn) {
 	<-doneCh
 
 	return clientConn, serverConn
+}
+
+func TestPrefixTokenErrorRetrieveError(t *testing.T) {
+	var r = require.New(t)
+
+	var err *oauth2.RetrieveError
+	if err := prefixTokenError("failed to get access token", err); err != nil {
+		r.Equal("ErrInvalidCredentials: failed to get access token: <nil>", err.Error())
+	} else {
+		t.Error("prefixHandshakeError did not return any prefixes error")
+	}
+}
+
+func TestPrefixTokenErrorNil(t *testing.T) {
+	var r = require.New(t)
+
+	var err error
+	if err := prefixTokenError("failed to get access token", err); err != nil {
+		r.Equal("failed to get access token", err.Error())
+	} else {
+		t.Error("prefixHandshakeError did not return any prefixes error")
+	}
+}
+
+func TestPrefixTokenErrorOther(t *testing.T) {
+	var r = require.New(t)
+
+	var err = errTimeErrorUnknown
+	if err := prefixTokenError("failed to get access token", err); err != nil {
+		r.Equal("failed to get access token: testing error", err.Error())
+	} else {
+		t.Error("prefixHandshakeError did not return any prefixes error")
+	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -481,39 +481,6 @@ func testConn(t *testing.T) (net.Conn, net.Conn) {
 	return clientConn, serverConn
 }
 
-func TestPrefixTokenErrorRetrieveError(t *testing.T) {
-	var r = require.New(t)
-
-	var err *oauth2.RetrieveError
-	if err := prefixTokenError("failed to get access token", err); err != nil {
-		r.Equal("ErrInvalidCredentials: failed to get access token: <nil>", err.Error())
-	} else {
-		t.Error("expected a prefixed error")
-	}
-}
-
-func TestPrefixTokenErrorNil(t *testing.T) {
-	var r = require.New(t)
-
-	var err error
-	if err := prefixTokenError("failed to get access token", err); err != nil {
-		r.Equal("failed to get access token", err.Error())
-	} else {
-		t.Error("expected a prefixed error")
-	}
-}
-
-func TestPrefixTokenErrorOther(t *testing.T) {
-	var r = require.New(t)
-
-	var err = errTimeErrorUnknown
-	if err := prefixTokenError("failed to get access token", err); err != nil {
-		r.Equal("failed to get access token: testing error", err.Error())
-	} else {
-		t.Error("expected a prefixed error")
-	}
-}
-
 func TestProviderSetupRetrieveError(t *testing.T) {
 	require := require.New(t)
 	addr, list := testListener(t)


### PR DESCRIPTION
# Description

This is a provider side error, the source is:

```
var oauthToken *oauth2.Token
oauthToken, err = p.config.HCPConfig.Token()
if err != nil {
	client.Close()
	err = fmt.Errorf("failed to get access token: %w", err)
	return nil, err
}
```

The error returned by `HCPConfig.Token()` should be of type [*oauth2.RetrieveError](https://cs.opensource.google/go/x/oauth2/+/f2134210:clientcredentials/clientcredentials.go;l=109)

# Notes

This PR changes some of the errors returned by `handshake()` by adding a prefix to them. That prefix is processed from a central location in the `run()` loop by calling `NewTimeError()`. 
