### PR TITLE
update the meta-data API

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,22 +34,22 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c == nil {
-		return fmt.Errorf("missing config")
+		return fmt.Errorf("failed to initialize SCADA provider: missing config")
 	}
 
 	if c.Service == "" {
-		return fmt.Errorf("missing Service")
+		return fmt.Errorf("failed to initialize SCADA provider: missing Service")
 	}
 
 	err := resource.Validate(c.Resource)
 	if err != nil {
-		return fmt.Errorf("resource is invalid: %w", err)
+		return fmt.Errorf("failed to initialize SCADA provider: %w", err)
 	}
 	if c.HCPConfig == nil {
-		return fmt.Errorf("missing HCPConfig")
+		return fmt.Errorf("failed to initialize SCADA provider: HCPConfig must be provided")
 	}
 	if c.Logger == nil {
-		return fmt.Errorf("missing Logger")
+		return fmt.Errorf("failed to initialize SCADA provider: Logger must be provided")
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -47,28 +47,28 @@ func TestConfig_Invalid(t *testing.T) {
 			mutate: func(config *Config) {
 				config.Service = ""
 			},
-			expectedError: "missing Service",
+			expectedError: "failed to initialize SCADA provider: missing Service",
 		},
 		{
 			name: "invalid resource",
 			mutate: func(config *Config) {
 				config.Resource.ID = ""
 			},
-			expectedError: "resource is invalid: missing resource ID",
+			expectedError: "failed to initialize SCADA provider: missing resource ID",
 		},
 		{
 			name: "missing HCP Config",
 			mutate: func(config *Config) {
 				config.HCPConfig = nil
 			},
-			expectedError: "missing HCPConfig",
+			expectedError: "failed to initialize SCADA provider: HCPConfig must be provided",
 		},
 		{
 			name: "missing Logger",
 			mutate: func(config *Config) {
 				config.Logger = nil
 			},
-			expectedError: "missing Logger",
+			expectedError: "failed to initialize SCADA provider: Logger must be provided",
 		},
 	}
 

--- a/interface.go
+++ b/interface.go
@@ -7,9 +7,17 @@ import (
 
 // SCADAProvider allows to expose services via SCADA capabilities.
 type SCADAProvider interface {
-	// UpdateMeta updates the internal map of meta-data values
-	// and performs a rehandshake to update the broker with the new values.
+	// UpdateMeta overwrites the internal map of meta-data values
+	// and performs a re-handshake to update the remote broker.
 	UpdateMeta(map[string]string)
+
+	// AddMeta upserts keys and values in the internal map of meta-data
+	// and performs a re-handshake to update the remote broker.
+	AddMeta(...Meta)
+
+	// DeleteMeta delete keys from the meta-date values and then perform a
+	// re-handshake to update the remote broker.
+	DeleteMeta(...string)
 
 	// GetMeta returns the provider's current meta-data.
 	GetMeta() map[string]string
@@ -83,3 +91,7 @@ const (
 	// previous connected and is now in a wait-connect cycle
 	SessionStatusWaiting = SessionStatus("waiting")
 )
+
+type Meta struct {
+	Key, Value string
+}

--- a/provider_test.go
+++ b/provider_test.go
@@ -36,6 +36,14 @@ func (p *Provider) isStopped() bool {
 	return !p.running
 }
 
+func TestProviderImplementsSCADAProvider(t *testing.T) {
+	r := require.New(t)
+
+	var givenProvider SCADAProvider
+	givenProvider, _ = New(testProviderConfig())
+	r.NotNil(givenProvider)
+}
+
 func TestSCADAProvider(t *testing.T) {
 	t.Run("SCADA provider initialization fails if no Logger is provided", func(t *testing.T) {
 		_, err := New(&Config{
@@ -179,7 +187,7 @@ func TestProvider_StartStop(t *testing.T) {
 	require := require.New(t)
 
 	// Create the provider, it should be stopped
-	p, err := construct(testProviderConfig())
+	p, err := New(testProviderConfig())
 	require.NoError(err)
 	require.True(p.isStopped())
 
@@ -216,7 +224,7 @@ func TestProvider_StartStop(t *testing.T) {
 
 func TestProvider_backoff(t *testing.T) {
 	require := require.New(t)
-	p, err := construct(testProviderConfig())
+	p, err := New(testProviderConfig())
 	require.NoError(err)
 
 	err = p.Start()
@@ -295,7 +303,7 @@ func TestProvider_Setup(t *testing.T) {
 	config := testProviderConfig()
 	config.HCPConfig = test.NewStaticHCPConfig(addr, false)
 
-	p, err := construct(config)
+	p, err := New(config)
 	require.NoError(err)
 
 	require.Equal(SessionStatusDisconnected, p.SessionStatus())
@@ -342,8 +350,9 @@ func TestProvider_Setup(t *testing.T) {
 func TestProvider_ListenerStop(t *testing.T) {
 	require := require.New(t)
 
+	var givenProvider SCADAProvider
 	givenCapability := "foo"
-	givenProvider, _ := New(testProviderConfig())
+	givenProvider, _ = New(testProviderConfig())
 	givenListener, _ := givenProvider.Listen(givenCapability)
 
 	err := givenListener.Close()
@@ -376,7 +385,7 @@ func TestProvider_Connect(t *testing.T) {
 	require := require.New(t)
 	config := testProviderConfig()
 
-	p, err := construct(config)
+	p, err := New(config)
 	p.handlers["foo"] = handler{
 		provider: fooCapability(t),
 	}
@@ -422,7 +431,7 @@ func TestProvider_Disconnect(t *testing.T) {
 	const testBackoff = 300 * time.Second
 	require := require.New(t)
 	config := testProviderConfig()
-	p, err := construct(config)
+	p, err := New(config)
 	require.NoError(err)
 
 	err = p.Start()
@@ -495,7 +504,7 @@ func TestProviderSetupRetrieveError(t *testing.T) {
 		},
 	})
 
-	p, err := construct(config)
+	p, err := New(config)
 	require.NoError(err)
 
 	require.Equal(SessionStatusDisconnected, p.SessionStatus())


### PR DESCRIPTION
# Description

1. Revert the behaviour of `UpdateMeta` to the original version and document it better
1. Create a `DeleteMeta` function that takes variadic `string` as keys
1. Create a `AddMeta` function that takes variadic `provider.Meta{key, value string}` as key values