### PR TITLE
Change "connect requested" log from info to debug

### DIFF
--- a/provider_endpoint.go
+++ b/provider_endpoint.go
@@ -37,7 +37,7 @@ func (pe *providerEndpoint) setHijack(cb hijackFunc) {
 
 // Connect is invoked by the broker to connect to a capability.
 func (pe *providerEndpoint) Connect(args *ConnectRequest, resp *ConnectResponse) error {
-	pe.p.logger.Info("connect requested", "capability", args.Capability)
+	pe.p.logger.Debug("connect requested", "capability", args.Capability)
 
 	// Handle potential flash
 	if args.Severity != "" && args.Message != "" {


### PR DESCRIPTION
### :hammer_and_wrench: Description

Consul calls out through SCADA every minute resulting in logs like:

```
2023-03-14T17:59:34.120Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:05:26.888Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:06:28.497Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:07:30.071Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:09:34.202Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:10:12.970Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:10:36.771Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:12:40.993Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
2023-03-14T18:13:42.622Z [INFO]  agent.hcp.scada.scada-provider: connect requested: capability=core_api
```

I'm proposing we move these logs to debug because I don't think making a connection out through scada needs to be at info level.