### PR TITLE
CC-7032: Support for updating the provider's configuration

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -68,6 +68,9 @@ type SCADAProvider interface {
 	//
 	// Any other internal error will be returned directly and unchanged.
 	LastError() (time.Time, error)
+
+	// UpdateConfig overwrites the provider's configuration with the given configuration.
+	UpdateConfig(config *Config) error
 }
 
 // SessionStatus is used to express the current status of the SCADA session.

--- a/provider.go
+++ b/provider.go
@@ -732,3 +732,14 @@ func calculateExpiryFactor(d time.Duration) time.Duration {
 	d = time.Duration(factored) * time.Second
 	return d
 }
+
+// UpdateConfig overwrites the provider's configuration
+// with the given configuration.
+func (p *Provider) UpdateConfig(config *Config) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+	p.config = config
+	p.logger = config.Logger.Named("scada-provider")
+	return nil
+}

--- a/provider.go
+++ b/provider.go
@@ -760,6 +760,5 @@ func (p *Provider) UpdateConfig(config *Config) error {
 		return err
 	}
 	p.config = config
-	p.logger = config.Logger.Named("scada-provider")
 	return nil
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -546,3 +546,34 @@ func TestProviderSetupRetrieveError(t *testing.T) {
 	require.Error(err)
 	require.Equal(ErrInvalidCredentials, err)
 }
+
+func TestProvider_UpdateConfig(t *testing.T) {
+	require := require.New(t)
+	originalConfig := testProviderConfig()
+	p, err := newProvider(originalConfig)
+	require.NoError(err)
+
+	updated := "updated-value"
+	updatedConfig := &Config{
+		Service: updated,
+		HCPConfig: test.NewStaticHCPConfig(
+			updated,
+			true,
+		),
+		Resource: cloud.HashicorpCloudLocationLink{
+			ID:   updated,
+			Type: resourceType,
+			Location: &cloud.HashicorpCloudLocationLocation{
+				ProjectID:      projectID,
+				OrganizationID: organizationID,
+			},
+		},
+		Logger: hclog.L(),
+	}
+
+	err = p.UpdateConfig(updatedConfig)
+	require.NoError(err)
+	require.Equal(updated, p.config.Service)
+	require.Equal(updated, p.config.HCPConfig.SCADAAddress())
+	require.Equal(updated, p.config.Resource.ID)
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description
Adds support for updating the SCADA provider configuration. We plan to create a SCADA provider in our code and then later update the config to set the the Resource and HCPConfig when those values are known.

### :link: External Links
- https://hashicorp.atlassian.net/browse/CC-7032

### :+1: Definition of Done
- [X] Tests added?
- [ ] Docs updated?
