### PR TITLE
UpdateMeta: log error message if action not triggered

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -123,7 +123,9 @@ func (p *Provider) UpdateMeta(m map[string]string) {
 	}
 
 	// tell the run loop to re-handshake and update the broker
-	p.action(actionRehandshake)
+	if err := p.action(actionRehandshake); err != nil {
+		p.logger.Warn("action not triggered (meta updated)", "error", err)
+	}
 }
 
 // AddMeta upserts keys and values in the internal map of meta-data

--- a/provider.go
+++ b/provider.go
@@ -125,9 +125,7 @@ func (p *Provider) UpdateMeta(m map[string]string) {
 	}
 
 	// tell the run loop to re-handshake and update the broker
-	if err := p.action(actionRehandshake); err != nil {
-		p.logger.Warn("actionRehandshake: not triggered for UpdateMeta", "error", err)
-	}
+	p.action(actionRehandshake)
 }
 
 // AddMeta upserts keys and values in the internal map of meta-data

--- a/provider.go
+++ b/provider.go
@@ -110,6 +110,8 @@ func newProvider(config *Config) (*Provider, error) {
 
 // UpdateMeta overwrites the internal map of meta-data values
 // and performs a re-handshake to update the remote broker.
+// If the provider isn't running, updated meta will be applied
+// after the provoder starts.
 func (p *Provider) UpdateMeta(m map[string]string) {
 	p.metaLock.Lock()
 	defer p.metaLock.Unlock()

--- a/provider.go
+++ b/provider.go
@@ -124,7 +124,7 @@ func (p *Provider) UpdateMeta(m map[string]string) {
 
 	// tell the run loop to re-handshake and update the broker
 	if err := p.action(actionRehandshake); err != nil {
-		p.logger.Warn("action not triggered (meta updated)", "error", err)
+		p.logger.Warn("actionRehandshake: not triggered for UpdateMeta", "error", err)
 	}
 }
 

--- a/provider_actions.go
+++ b/provider_actions.go
@@ -18,9 +18,23 @@ func (p *Provider) action(a action) error {
 	defer p.runningLock.Unlock()
 
 	if !p.running {
+		p.logger.Warn("action not triggered", "action", actionStr(a), "reason", "provider isn't running")
 		return errNotRunning
 	}
 
 	p.actions <- a
 	return nil
+}
+
+func actionStr(a action) string {
+	switch a {
+	case actionDefault:
+		return "actionDefault"
+	case actionRehandshake:
+		return "actionRehandshake"
+	case actionDisconnect:
+		return "actionDisconnect"
+	default:
+		return "unknown action"
+	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -577,3 +577,17 @@ func TestProvider_UpdateConfig(t *testing.T) {
 	require.Equal(updated, p.config.HCPConfig.SCADAAddress())
 	require.Equal(updated, p.config.Resource.ID)
 }
+
+func TestProvider_actionStr(t *testing.T) {
+	testCases := []struct {
+		a           action
+		expectedStr string
+	}{
+		{actionDefault, "actionDefault"},
+		{actionRehandshake, "actionRehandshake"},
+		{actionDisconnect, "actionDisconnect"},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.expectedStr, actionStr(tc.a))
+	}
+}


### PR DESCRIPTION
For dev and test purposes, it's helpful to know if the action is triggered or not.

* Why not return an error?

The meta is updated, so this may not be considered an error. So a warning message should be sufficient.


### :hammer_and_wrench: Description

<!-- What code changed, and why? What are the key new features or breaking changes? -->

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] Tests added?
- [ ] Docs updated?
