### PR TITLE
Prevent potential connection leak if initial ping fails.

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -83,6 +83,8 @@ func initClient(conn net.Conn, opts *Opts) (*Client, error) {
 	}
 	_, err = client.Ping()
 	if err != nil {
+		// Close the connection here so that it isn't leaked if the ping fails.
+		client.Close()
 		return nil, fmt.Errorf("yamux ping failed: %w", err)
 	}
 


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Prior to this change, it was possible for the Yamux connection to be established and not told to shutdown. This can occur if the initial handshake succeeded, but the subsequent ping failed afterwards.

While not likely an actual problem due to [the stream detecting an I/O error and triggering a shutdown itself](https://github.com/hashicorp/yamux/blob/9e980a5a29bca84539fa6271239da99f8962fa38/session.go#L532-L534), this commit explicitly ensures that a shutdown is always signaled.

### :link:  External Links

Jira: hcpcp-2255


### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC

## PCI review checklist

- [ ] If applicable, I’ve documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I’ve worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I’ve worked with GRC to ensure compliance due to a significant change to the cardholder data environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.
